### PR TITLE
Fallback to spark 2.3 jars

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,4 +1,6 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
+  if (spark_version > "2.3") spark_version <- "2.3"
+    
   sparklyr::spark_dependency(
     jars = c(
       system.file(


### PR DESCRIPTION
I was testing with Spark 2.4 and hit a warning regarding missing jars.